### PR TITLE
Add some parsing logic for Algebraic Notation.

### DIFF
--- a/game.txt
+++ b/game.txt
@@ -1,0 +1,20 @@
+1. e4 e5
+2. Nf3 Nc6
+3. Bb5 f6
+4. Bxc6 dxc6
+5. Nxe5 fxe5
+6. Qh5+ Kd7
+7. Qxe5 Qf6
+8. Qg3 Bd6
+9. Qb3 Ne7
+10. O-O Qe5
+11. f4 Qxe4
+12. Nc3 Qd4+
+13. Kh1 Rf8
+14. d3 Bxf4
+15. Ne4 Ng6
+16. c3 Qb6
+17. Bxf4 Qxb3
+18. Nc5+ Kd8
+19. Bg5+ Ne7
+20. Rxf8#

--- a/src/chess/parser.py
+++ b/src/chess/parser.py
@@ -1,0 +1,142 @@
+"""
+Module that can parse chess notation for individual moves. Mostly to debug
+things and/or introduce chess states without having to wire up the entire
+camera setup on a physical board.
+
+Note that we're using standard Algebraic Notation:
+
+https://en.wikipedia.org/wiki/Algebraic_notation_(chess)
+
+Maybe we move on to FEN https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
+to start from boards?
+
+BUGS:
+  - Doesn't handle pawn promotions
+  - Doesn't handle disambiguations (when two knights can reach the same place)
+"""
+import re
+from enum import Enum
+from collections import namedtuple
+
+
+# Data definitions. Currently don't allow for draws.
+Piece = Enum('Piece', 'Pawn Rook Knight Bishop Queen King')
+Action = Enum('Action', 'Move Capture CastleKingside CastleQueenside PawnPromotion')
+Modifier = Enum('Modifier', 'Check CheckMate')
+
+Col = Enum('Col', 'A B C D E F G H')
+Row = Enum('Row', 'One Two Three Four Five Six Seven Eight')
+
+Position = namedtuple('Position', 'row col')
+Move = namedtuple('Move', 'piece action position modifiers')
+# Black could be None in the case of a white Checkmate
+Turn = namedtuple('Turn', 'white black')
+
+LINE_REGEX = re.compile('(?:\d+\.\s+)\s*(\S+)(?:\s+(\S+)\s*)?$')
+POSITION_PATTERN = '([a-h])(1|2|3|4|5|6|7|8)'
+POSITION_REGEX = re.compile(POSITION_PATTERN)
+PIECE_MAP = {
+    'B': Piece.Bishop,
+    'R': Piece.Rook,
+    'Q': Piece.Queen,
+    'K': Piece.King,
+    'N': Piece.Knight
+}
+COL_MAP = {'a': Col.A, 'b': Col.B, 'c': Col.C, 'd': Col.D, 'e': Col.E, 'f': Col.F, 'g': Col.G, 'h': Col.H}
+ROW_MAP = {
+    '1': Row.One,
+    '2': Row.Two,
+    '3': Row.Three,
+    '4': Row.Four,
+    '5': Row.Five,
+    '6': Row.Six,
+    '7': Row.Seven,
+    '8': Row.Eight
+}
+ACTION_MAP = {
+    'x': Action.Capture,
+    'O-O': Action.CastleKingside,
+    'O-O-O': Action.CastleQueenside,
+    '=': Action.PawnPromotion
+}
+
+
+def parse_file(filename):
+    with open(filename) as f:
+        lines = f.readlines()
+        return [parse_line(line.rstrip('\n')) for line in lines]
+
+
+def parse_line(line):
+    components = LINE_REGEX.match(line)
+    white_move = _parse_move(components.group(1))
+
+    black_move = None
+    black_move_spec = components.group(2)
+    if black_move_spec:
+        black_move = _parse_move(black_move_spec)
+    return Turn(white=white_move, black=black_move)
+
+
+def _parse_move(move):
+    if re.match('O-O-O', move):
+        return Move(piece=None, action=Action.CastleQueenside, position=None, modifiers=[])
+    elif re.match('O-O', move):
+        return Move(piece=None, action=Action.CastleKingside, position=None, modifiers=[])
+
+    piece = _get_piece(move)
+    action = _get_action(move)
+    position = _get_position(move)
+    modifiers = _get_modifiers(move)
+    return Move(piece=piece, action=action, position=position, modifiers=modifiers)
+
+
+def _get_piece(move):
+    """
+    The piece is realatively easy to determine: it's either a pawn, or directly
+    determined by its first letter. Gets _a little_ weird for when pawns capture,
+    so we default to that if the first character isnt' a recognized one.
+    """
+    match = re.search('^' + POSITION_PATTERN, move)
+    if match:
+        return Piece.Pawn
+    else:
+        return PIECE_MAP.get(move[0], Piece.Pawn)
+
+
+def _get_action(move):
+    for action in ACTION_MAP.iterkeys():
+        if re.search(action, move):
+            return ACTION_MAP[action]
+    return Action.Move
+
+
+def _get_position(move):
+    """
+    The position is pretty easily determined by one of the "acceptable letters" followed by
+    an acceptable number.
+    """
+    match = POSITION_REGEX.search(move)
+    return Position(col=COL_MAP[match.group(1)], row=ROW_MAP[match.group(2)])
+
+
+def _get_modifiers(move):
+    modifiers = []
+    if re.search('\+', move):
+        modifiers.append(Modifier.Check)
+    elif re.search('#', move):
+        modifiers.append(Modifier.CheckMate)
+    return modifiers
+
+
+def test_data():
+    return [
+           Turn(white=Move(piece=Piece.Pawn,
+                           action=Action.Move,
+                           position=Position(col=Col.E, row=Row.Four),
+                           modifiers=[]),
+                black=Move(piece=Piece.Pawn,
+                           action=Action.Move,
+                           position=Position(col=Col.E, row=Row.Five),
+                           modifiers=[])),
+            ]

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ import gamestate
 import camera
 import media
 
+
 logging.basicConfig()
 EVENTS = Events()
 
@@ -29,7 +30,7 @@ def print_welcome():
 ░  ░  ░  ░          ░░   ░    ░    ░   ▒   ░      ░      ░         ░  ░░ ░   ░   ░  ░  ░  ░  ░  ░
       ░  ░ ░         ░        ░  ░     ░  ░       ░      ░ ░       ░  ░  ░   ░  ░      ░        ░
          ░                                               ░
-                                          by Karblora
+                                          by Karbloraide
 
 Instructions:
 """


### PR DESCRIPTION
_The song for this PR is [WEAPON](https://www.youtube.com/watch?v=3vC5TsSyNjU), by M4SONIC._

Adds some code that can parse [Algebraic Chess Notation](https://en.wikipedia.org/wiki/Algebraic_notation_(chess)), like the kind used in chess books and (RIP) newspaper columns. `game.txt` is included as one such game described.

Note that the internal format I'm using is extremely bespoke, I plan on backporting it with Karen's work when she finishes it 😄 For that reason, I'm pushing it, but have no intention of merging for a bit.

The main goal of having this parser is so that we can take a list of moves and simulate board movements in an analog way, without necessarily getting the rigamarole of the box/camera. It's the first step in a "player" which can start with this list of moves, then "play" each one in succession, playing a sound + printing the board to console (ideally with unicode characters like ♘ or ♟)